### PR TITLE
Adding support for analog inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/beskar-co/use-gamepad-events#readme",
   "devDependencies": {
     "@beskar-labs/harmony": "^2.1.1",
+    "@types/lodash.isequal": "^4.5.6",
     "@types/react": "^18.0.31",
     "@types/react-dom": "^18.0.11",
     "eslint": "^8.37.0",
@@ -55,6 +56,7 @@
     "react-dom": "^18.2.0"
   },
   "dependencies": {
-    "@react-hookz/web": "^23.0.0"
+    "@react-hookz/web": "^23.0.0",
+    "lodash.isequal": "^4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "homepage": "https://github.com/beskar-co/use-gamepad-events#readme",
   "devDependencies": {
     "@beskar-labs/harmony": "^2.1.1",
+    "@types/lodash.debounce": "^4.0.7",
     "@types/lodash.isequal": "^4.5.6",
     "@types/react": "^18.0.31",
     "@types/react-dom": "^18.0.11",
@@ -57,6 +58,7 @@
   },
   "dependencies": {
     "@react-hookz/web": "^23.0.0",
+    "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable id-length */
 import { useEventListener } from '@react-hookz/web';
 import { useCallback, useEffect, useState } from 'react';
 import isEqual from 'lodash.isequal';
@@ -44,10 +45,6 @@ const defaultState: GamepadState = {
   right: false,
   back: false,
 };
-
-let lastFiredButton: keyof GamepadState | null = null;
-// eslint-disable-next-line jest/require-hook
-let lastFiredTime = 0;
 
 const useGamepadEvents = (
   props?: UseGamepadEventsProps
@@ -191,22 +188,6 @@ const useGamepadEvents = (
     callback: (value: GamepadState[T]) => void
   ) => {
     if (isEqual(gamepadState[button], lastGamepadState[button])) return;
-
-    const now = Date.now();
-
-    if (!lastFiredButton || !lastFiredTime || lastFiredButton !== button) {
-      lastFiredButton = button;
-      lastFiredTime = now;
-      callback(gamepadState[button]);
-      return;
-    }
-
-    if (now - lastFiredTime < 100 && lastFiredButton === button) {
-      lastFiredTime = now;
-      return;
-    }
-
-    lastFiredTime = now;
     callback(gamepadState[button]);
   };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,10 @@ let lastFiredTime = 0;
 const useGamepadEvents = (
   props?: UseGamepadEventsProps
 ): {
-  on: (event: keyof GamepadState, callback: () => void) => void;
+  on: <T extends keyof GamepadState>(
+    button: T,
+    callback: (value: GamepadState[T]) => void
+  ) => void;
 } => {
   const [gamepad, setGamepad] = useState<number | null>(null);
   const [gamepadState, setGamepadState] = useState<GamepadState>(defaultState);
@@ -179,7 +182,10 @@ const useGamepadEvents = (
     setRunning(true);
   }, [gameloop, gamepad, gamepadState, running]);
 
-  const on = (button: keyof GamepadState, callback: () => void) => {
+  const on = <T extends keyof GamepadState>(
+    button: T,
+    callback: (value: GamepadState[T]) => void
+  ) => {
     if (!gamepadState[button]) {
       return;
     }
@@ -189,7 +195,7 @@ const useGamepadEvents = (
     if (!lastFiredButton || !lastFiredTime || lastFiredButton !== button) {
       lastFiredButton = button;
       lastFiredTime = now;
-      callback();
+      callback(gamepadState[button]);
       return;
     }
 
@@ -199,7 +205,7 @@ const useGamepadEvents = (
     }
 
     lastFiredTime = now;
-    callback();
+    callback(gamepadState[button]);
   };
 
   return { on };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { useEventListener } from '@react-hookz/web';
 import { useCallback, useEffect, useState } from 'react';
+import isEqual from 'lodash.isequal';
 
 export type GamepadState = {
   a: boolean;
@@ -58,6 +59,8 @@ const useGamepadEvents = (
 } => {
   const [gamepad, setGamepad] = useState<number | null>(null);
   const [gamepadState, setGamepadState] = useState<GamepadState>(defaultState);
+  const [lastGamepadState, setlastGamepadState] =
+    useState<GamepadState>(defaultState);
   const [ready, setReady] = useState(false);
   const [running, setRunning] = useState(false);
   const { onReady, onLoop, onConnect, onDisconnect } = props ?? {};
@@ -111,6 +114,7 @@ const useGamepadEvents = (
        */
 
       if (JSON.stringify(newState) !== JSON.stringify(oldState)) {
+        setlastGamepadState(oldState);
         setGamepadState(newState);
       }
 
@@ -186,9 +190,7 @@ const useGamepadEvents = (
     button: T,
     callback: (value: GamepadState[T]) => void
   ) => {
-    if (!gamepadState[button]) {
-      return;
-    }
+    if (isEqual(gamepadState[button], lastGamepadState[button])) return;
 
     const now = Date.now();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 import { useEventListener } from '@react-hookz/web';
 import { useCallback, useEffect, useState } from 'react';
 import isEqual from 'lodash.isequal';
+import debounce from 'lodash.debounce';
 
 export type GamepadState = {
   a: boolean;
@@ -204,12 +205,17 @@ const useGamepadEvents = (
     setRunning(true);
   }, [gameloop, gamepad, gamepadState, running]);
 
+  const debounced_on = useCallback(
+    debounce((callback: () => void) => callback(), 50, { maxWait: 50 }),
+    []
+  );
+
   const on = <T extends keyof GamepadState>(
     button: T,
     callback: (value: GamepadState[T]) => void
   ) => {
     if (isEqual(gamepadState[button], lastGamepadState[button])) return;
-    callback(gamepadState[button]);
+    debounced_on(() => callback(gamepadState[button]));
   };
 
   return { on };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,10 @@ export type GamepadState = {
   x: boolean;
   y: boolean;
   l1: boolean;
+  l2: number;
   l3: boolean;
   r1: boolean;
+  r2: number;
   r3: boolean;
   share: boolean;
   options: boolean;
@@ -19,6 +21,13 @@ export type GamepadState = {
   left: boolean;
   right: boolean;
   back: boolean;
+  leftStick: GamepadJoystick;
+  rightStick: GamepadJoystick;
+};
+
+type GamepadJoystick = {
+  x: number;
+  y: number;
 };
 
 type UseGamepadEventsProps = {
@@ -34,8 +43,10 @@ const defaultState: GamepadState = {
   x: false,
   y: false,
   l1: false,
+  l2: 0,
   l3: false,
   r1: false,
+  r2: 0,
   r3: false,
   share: false,
   options: false,
@@ -44,6 +55,8 @@ const defaultState: GamepadState = {
   left: false,
   right: false,
   back: false,
+  leftStick: { x: 0, y: 0 },
+  rightStick: { x: 0, y: 0 },
 };
 
 const useGamepadEvents = (
@@ -78,14 +91,16 @@ const useGamepadEvents = (
         return;
       }
 
-      const newState = {
+      const newState: GamepadState = {
         a: activeGamepad.buttons[0].pressed,
         b: activeGamepad.buttons[1].pressed,
         x: activeGamepad.buttons[2].pressed,
         y: activeGamepad.buttons[3].pressed,
         l1: activeGamepad.buttons[4].pressed,
+        l2: Number(activeGamepad.buttons[6].value.toFixed(4)),
         l3: activeGamepad.buttons[10].pressed,
         r1: activeGamepad.buttons[5].pressed,
+        r2: Number(activeGamepad.buttons[7].value.toFixed(4)),
         r3: activeGamepad.buttons[11].pressed,
         share: activeGamepad.buttons[8].pressed,
         options: activeGamepad.buttons[9].pressed,
@@ -94,21 +109,27 @@ const useGamepadEvents = (
         left: activeGamepad.buttons[14].pressed,
         right: activeGamepad.buttons[15].pressed,
         back: activeGamepad.buttons[16].pressed,
+        leftStick: {
+          x:
+            activeGamepad.axes[0] < -0.08 || activeGamepad.axes[0] > 0.08
+              ? Number(activeGamepad.axes[0].toFixed(4))
+              : 0,
+          y:
+            activeGamepad.axes[1] < -0.08 || activeGamepad.axes[1] > 0.08
+              ? Number(activeGamepad.axes[1].toFixed(4))
+              : 0,
+        },
+        rightStick: {
+          x:
+            activeGamepad.axes[2] < -0.08 || activeGamepad.axes[2] > 0.08
+              ? Number(activeGamepad.axes[2].toFixed(4))
+              : 0,
+          y:
+            activeGamepad.axes[3] < -0.08 || activeGamepad.axes[3] > 0.08
+              ? Number(activeGamepad.axes[3].toFixed(4))
+              : 0,
+        },
       };
-
-      /*
-       * const leftStick = {
-       *   x: Number(activeGamepad.axes[0].toFixed(2)),
-       *   y: Number(activeGamepad.axes[1].toFixed(2)),
-       * };
-       */
-
-      /*
-       * const rightStick = {
-       *   x: Number(activeGamepad.axes[2].toFixed(2)),
-       *   y: Number(activeGamepad.axes[3].toFixed(2)),
-       * };
-       */
 
       if (JSON.stringify(newState) !== JSON.stringify(oldState)) {
         setlastGamepadState(oldState);

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash.debounce@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz#0285879defb7cdb156ae633cecd62d5680eded9f"
+  integrity sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.isequal@^4.5.6":
   version "4.5.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
@@ -3351,6 +3358,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.isequal@^4.5.0:
   version "4.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -885,6 +885,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/lodash.isequal@^4.5.6":
+  version "4.5.6"
+  resolved "https://registry.yarnpkg.com/@types/lodash.isequal/-/lodash.isequal-4.5.6.tgz#ff42a1b8e20caa59a97e446a77dc57db923bc02b"
+  integrity sha512-Ww4UGSe3DmtvLLJm2F16hDwEQSv7U0Rr8SujLUA2wHI2D2dm8kPu6Et+/y303LfjTIwSBKXB/YTUcAKpem/XEg==
+  dependencies:
+    "@types/lodash" "*"
+
+"@types/lodash@*":
+  version "4.14.194"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.194.tgz#b71eb6f7a0ff11bff59fc987134a093029258a76"
+  integrity sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==
+
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -3339,6 +3351,11 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.merge@^4.6.2:
   version "4.6.2"


### PR DESCRIPTION
This PR implements support for the analog inputs on a game pad.  (issue #50)

To be able to access the current analog value, the callback function of ``.on()``  now returns the value of the input.
The callback now also gets called upon releasing the button.

To allow the value of the analog inputs to be updated properly, the delay in the ``.on()`` function was removed. 

I am open to any feedback and would be happy if this gets merged. 